### PR TITLE
Update S3_triggered_import.yaml S3 note

### DIFF
--- a/cloudformation/S3_triggered_import.yaml
+++ b/cloudformation/S3_triggered_import.yaml
@@ -9,7 +9,7 @@ Parameters:
 
   FileDropS3Bucket:
     Type: String
-    Description: Name of the Amazon S3 Bucket where new import files will be placed.
+    Description: Name of the existing Amazon S3 Bucket where new import files will be placed.
 
   FileDropS3Prefix:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clarification in the S3_triggered_import.yaml that the S3 bucket has to be an existing one. The template does not create it and if it's not a valid bucket, it will error on deploy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
