### PR TITLE
Update python version in SES bounce logging

### DIFF
--- a/cloudformation/ses_bounce_logging_blog.yml
+++ b/cloudformation/ses_bounce_logging_blog.yml
@@ -50,7 +50,7 @@ Resources:
             Role: !GetAtt LambdaRole.Arn
             Timeout: 60
             Handler: index.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.8
             MemorySize: 128
             Code:
                 ZipFile: |


### PR DESCRIPTION
https://github.com/aws-samples/communication-developer-services-reference-architectures/issues/17

*Description of changes:*

This will update the Python runtime used in lambda for the SES Bounce Logging. At the time of writing python 3.8 has not set deprecation date https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
