### PR TITLE
SES bounce logging needed a change to the lambda role

### DIFF
--- a/cloudformation/ses_bounce_logging_blog.yml
+++ b/cloudformation/ses_bounce_logging_blog.yml
@@ -27,7 +27,7 @@ Resources:
             AssumeRolePolicyDocument: {Version: '2012-10-17', Statement: [{Effect: Allow, Principal: {Service: [lambda.amazonaws.com]}, Action: ['sts:AssumeRole']}]}
             Policies:
             - PolicyName: cloudwatch_write_policy
-              PolicyDocument: {Version: '2012-10-17', Statement: [{Effect: Allow, Action: ['logs:CreateLogGroup','logs:CreateLogStream','logs:PutLogEvents','logs:DescribeLogStreams'], "Resource" :['arn:aws:logs:*:*:log-group:/aws/ses/*']}]}
+              PolicyDocument: {Version: '2012-10-17', Statement: [{Effect: Allow, Action: ['logs:CreateLogGroup','logs:CreateLogStream','logs:PutLogEvents','logs:DescribeLogStreams'], "Resource" :['arn:aws:logs:*:*:log-group:/aws/lambda/*','arn:aws:logs:*:*:log-group:/aws/ses/*']}]}
             Path: /
     SnsSubscription:
         Type: AWS::SNS::Subscription


### PR DESCRIPTION
*Description of changes:*
Added additional resource 'arn:aws:logs:*:*:log-group:/aws/lambda/*' to the policy document.

*Explanation*
Because lambda functions log to cloudwatch logs, the LambdaRole needs to be able to create the log group for that so needs CreateLogGroup access for resounce '/aws/lambda/*'. Without this the lambda console function monitoring page reports an error as the log group for monitoring executions won't exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


