### PR TITLE
Update python version in SES bounce logging

### DIFF
--- a/cloudformation/ses_bounce_logging_blog.yml
+++ b/cloudformation/ses_bounce_logging_blog.yml
@@ -50,7 +50,7 @@ Resources:
             Role: !GetAtt LambdaRole.Arn
             Timeout: 60
             Handler: index.lambda_handler
-            Runtime: python3.8
+            Runtime: python3.12
             MemorySize: 128
             Code:
                 ZipFile: |


### PR DESCRIPTION
*Issue #, if available:*
No issue.
*Description of changes:*
Python 3.8 will be deprecated soon in Lambda. Python 3.12 is fully working with this stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
